### PR TITLE
If patroni isn't running, keep retrying to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,11 @@ Connects to Patroni's metrics endpoint and exports metrics in Prometheus format.
 Expects Patroni to be running on localhost:8008.
 
 Exports metrics on port 9394 at `/metrics`.
+
+## Running Locally
+
+You need to install Go `brew install golang`.
+
+Then run `go build` to build and install dependencies.
+
+To run the project run `./patroni-exporter`. Remember to run `go build` after making changes

--- a/main.go
+++ b/main.go
@@ -85,7 +85,8 @@ func updateMetrics(httpClient http.Client, url string) {
 
 	res, getErr := httpClient.Do(req)
 	if getErr != nil {
-		log.Fatal(getErr)
+		log.Print(getErr)
+		return;
 	}
 
 	body, readErr := ioutil.ReadAll(res.Body)


### PR DESCRIPTION
resolves #1 

**Motivation** 

This means the exporter won't crash if the patroni instance isn't yet running. 